### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/blueplanet/pivotal_tracker_pr.png?label=ready&title=Ready)](https://waffle.io/blueplanet/pivotal_tracker_pr)
 # PivotalTrackerPr
 - `PivotalTracker`のストリーIDとストリー名を取得し、カレントブランチの`PullRequest`を作成する
 


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/blueplanet/pivotal_tracker_pr

This was requested by a real person (user blueplanet) on waffle.io, we're not trying to spam you.
