### PR TITLE
fix syntax error

### DIFF
--- a/lib/pivotal_tracker_pr/cli.rb
+++ b/lib/pivotal_tracker_pr/cli.rb
@@ -97,7 +97,7 @@ module PivotalTrackerPr
     end
 
     def default_message(story_id, story_name)
-      <<~EOF
+      <<-EOF
         [fixed ##{story_id}]#{story_name}
 
         #{story_link story_id}

--- a/lib/pivotal_tracker_pr/cli.rb
+++ b/lib/pivotal_tracker_pr/cli.rb
@@ -98,9 +98,9 @@ module PivotalTrackerPr
 
     def default_message(story_id, story_name)
       <<-EOF
-        [fixed ##{story_id}]#{story_name}
+[fixed ##{story_id}]#{story_name}
 
-        #{story_link story_id}
+#{story_link story_id}
       EOF
     end
 


### PR DESCRIPTION
こうなりました。

```
SyntaxError: /Users/kawakami/works/www/HanaSou/vendor/bundle/ruby/2.2.0/gems/pivotal_tracker_pr-0.3.5/lib/pivotal_tracker_pr/cli.rb:100: syntax error, unexpected <<
      <<~EOF
        ^
```
